### PR TITLE
hide menu options from BikeStoreFragmentActivity. leading to a large …

### DIFF
--- a/app/src/main/java/com/google/android/gms/samples/wallet/LoginActivity.java
+++ b/app/src/main/java/com/google/android/gms/samples/wallet/LoginActivity.java
@@ -18,6 +18,7 @@ package com.google.android.gms.samples.wallet;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.view.Menu;
 
 public class LoginActivity extends BikestoreFragmentActivity {
 
@@ -35,6 +36,11 @@ public class LoginActivity extends BikestoreFragmentActivity {
                 .add(R.id.login_fragment, fragment)
                 .commit();
         }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
When entering the LoginActivity the options menu is still present which would allow the login option to be pressed continually spawning new Activities until a surely impending doom.
