### PR TITLE
Move button location

### DIFF
--- a/app/src/main/res/layout/activity_checkout.xml
+++ b/app/src/main/res/layout/activity_checkout.xml
@@ -33,14 +33,6 @@
 
         <include layout="@layout/horizontal_divider" />
 
-        <Button
-            android:id="@+id/button_regular_checkout"
-            android:layout_width="@dimen/buy_button_width"
-            android:layout_height="wrap_content"
-            android:text="@string/continue_checkout"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginBottom="@dimen/padding_large" />
-
         <!--
             This FrameLayout is a placeholder for the Google Wallet button and will be provided
             by a fragment at runtime.
@@ -50,16 +42,24 @@
             android:layout_height="@dimen/buy_button_height"
             android:layout_width="@dimen/buy_button_width"
             android:layout_gravity="center_horizontal"
-            android:layout_marginTop="@dimen/margin_xlarge"
-            android:layout_marginBottom="@dimen/margin_xlarge" />
+            android:layout_marginTop="@dimen/margin_xlarge" />
 
         <CheckBox
             android:id="@+id/checkbox_stripe"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_xlarge"
             android:text="@string/stripe_checkbox_text"
             android:checked="false"
-            android:layout_gravity="center_horizontal"/>
+            android:layout_gravity="center_horizontal" />
+
+        <Button
+            android:id="@+id/button_regular_checkout"
+            android:layout_width="@dimen/buy_button_width"
+            android:layout_height="wrap_content"
+            android:text="@string/continue_checkout"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="@dimen/padding_large" />
 
         <Button
             android:id="@+id/button_return_to_shopping"


### PR DESCRIPTION
Android Pay button should always be above conventional checkout button.
