### PR TITLE
Moved error checking on CheckoutActivity and ConfirmationActivity to the right switch statements

### DIFF
--- a/app/src/main/java/com/google/android/gms/samples/wallet/CheckoutActivity.java
+++ b/app/src/main/java/com/google/android/gms/samples/wallet/CheckoutActivity.java
@@ -149,15 +149,15 @@ public class CheckoutActivity extends BikestoreFragmentActivity implements
                             launchConfirmationPage(maskedWallet);
                         }
                         break;
+                    case WalletConstants.RESULT_ERROR:
+                        handleError(errorCode);
+                        break;
                     case Activity.RESULT_CANCELED:
                         break;
                     default:
                         handleError(errorCode);
                         break;
                 }
-                break;
-            case WalletConstants.RESULT_ERROR:
-                handleError(errorCode);
                 break;
             default:
                 super.onActivityResult(requestCode, resultCode, data);

--- a/app/src/main/java/com/google/android/gms/samples/wallet/ConfirmationActivity.java
+++ b/app/src/main/java/com/google/android/gms/samples/wallet/ConfirmationActivity.java
@@ -92,20 +92,29 @@ public class ConfirmationActivity extends BikestoreFragmentActivity {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        int errorCode = 0;
+        if (data != null) {
+            errorCode = data.getIntExtra(WalletConstants.EXTRA_ERROR_CODE, 0);
+        }
         switch (requestCode) {
             case REQUEST_CODE_CHANGE_MASKED_WALLET:
-                if (resultCode == Activity.RESULT_OK &&
-                        data.hasExtra(WalletConstants.EXTRA_MASKED_WALLET)) {
-                    mMaskedWallet = data.getParcelableExtra(WalletConstants.EXTRA_MASKED_WALLET);
-                    ((FullWalletConfirmationButtonFragment) getResultTargetFragment())
-                            .updateMaskedWallet(mMaskedWallet);
+                switch (resultCode) {
+                    case Activity.RESULT_OK:
+                        if (data != null && data.hasExtra(WalletConstants.EXTRA_MASKED_WALLET)) {
+                            mMaskedWallet = data.getParcelableExtra(WalletConstants.EXTRA_MASKED_WALLET);
+                            ((FullWalletConfirmationButtonFragment) getResultTargetFragment())
+                                    .updateMaskedWallet(mMaskedWallet);
+                        }
+                        break;
+                    case WalletConstants.RESULT_ERROR:
+                        handleError(errorCode);
+                        break;
+                    case Activity.RESULT_CANCELED:
+                        break;
+                    default:
+                        handleError(errorCode);
+                        break;
                 }
-                  // you may also want to use the new masked wallet data here, say to recalculate
-                  // shipping or taxes if shipping address changed
-                break;
-            case WalletConstants.RESULT_ERROR:
-                int errorCode = data.getIntExtra(WalletConstants.EXTRA_ERROR_CODE, 0);
-                handleError(errorCode);
                 break;
             default:
                 super.onActivityResult(requestCode, resultCode, data);


### PR DESCRIPTION
The code was checking requestCode instead of resultCode.

Reported in #30 